### PR TITLE
Changes for matchbox and authbox to use % instead of vh for height

### DIFF
--- a/client-mobile/www/css/style.css
+++ b/client-mobile/www/css/style.css
@@ -32,7 +32,7 @@
   margin: 0 auto;
 }
 #authbox-container {
-  height: 100vh;
+  height: 100%;
   text-align: center;
 }
 .authbox-button-container {
@@ -54,7 +54,7 @@ div.image {
 
 /* Match View */
 #matchbox-container {
-  height: 100vh;
+  height: 100%;
 }
 .matchbox-button-container {
   text-align: center;


### PR DESCRIPTION
Small change.  This correctly uses 100% instead of 100vh for height for the matchbox and authbox containers.  This was making it so the user can scroll further down for these windows even though it was just whitespace.
